### PR TITLE
Add time, NPCs, and fame systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,55 @@
 # terminalRPG
 
+TerminalRPG é um jogo de RPG baseado em texto executado no terminal.
 
+## Adicionando conteúdo
+
+### Localidades
+As localidades do mundo estão definidas em `data/worldMap.json`. Cada entrada possui
+`id`, `name`, `description` e pode conter sublocalizações como continentes, reinos e vilas.
+
+### Missões
+As missões são armazenadas em `data/quests.json` e possuem o formato:
+
+```
+{
+  "id": "main_001",
+  "name": "A Chegada",
+  "type": "primary", // ou "secondary"
+  "description": "Fale com o ancião...",
+  "location": "vila_inicial",
+  "objectives": ["Conversar com o ancião"],
+  "rewards": { "xp": 50, "gold": 10, "fame": 5 },
+  "conditions": { "minLevel": 1, "relations": { "chefe_vila": 5 } }
+}
+```
+
+Use `type` para diferenciar missões principais e secundárias. O campo `location`
+recebe o `id` da localidade onde a missão fica disponível. Utilize `objectives`
+e `rewards` para detalhar cada missão. Em `conditions` é possível exigir nível
+mínimo, fama (`fame`) ou relacionamento com NPCs específicos (`relations`).
+
+### NPCs
+NPCs são definidos em `data/npcs.json` com campos como `id`, `name`,
+`dialogue`, `dialogueFamous` e `schedules` indicando em quais horas estão
+presentes em determinadas localidades.
+
+```
+{
+  "id": "chefe_vila",
+  "name": "Chefe da Vila",
+  "dialogue": ["Saudações, viajante."],
+  "dialogueFamous": ["Ah, o herói de quem todos falam!"],
+  "schedules": [ { "location": "vila_inicial", "start": 8, "end": 20 } ]
+}
+```
+
+### Tempo e Fama
+O jogo mantém um relógio interno (`flags.time.hour`). Cada hora de jogo
+equivale a 60 segundos do mundo real. Dormir na estalagem avança 8 horas e
+restaura 50% de HP e MP. Interagir ou passar tempo com NPCs também pode
+avançar o relógio. O jogador possui um atributo de fama (`fame`) que pode ser
+recompensado em missões e altera diálogos com NPCs.
 
 ## Getting started
 

--- a/data/npcs.json
+++ b/data/npcs.json
@@ -1,0 +1,14 @@
+{
+  "npcs": [
+    {
+      "id": "chefe_vila",
+      "name": "Chefe da Vila",
+      "role": "chieftain",
+      "dialogue": ["Saudações, viajante."],
+      "dialogueFamous": ["Ah, o herói de quem todos falam!"],
+      "schedules": [
+        { "location": "vila_inicial", "start": 8, "end": 20 }
+      ]
+    }
+  ]
+}

--- a/data/quests.json
+++ b/data/quests.json
@@ -1,0 +1,29 @@
+{
+  "quests": [
+  {
+      "id": "main_001",
+      "name": "A Chegada",
+      "type": "primary",
+      "description": "Fale com o ancião da Vila Inicial para iniciar sua jornada.",
+      "location": "vila_inicial",
+      "objectives": ["Conversar com o ancião"],
+      "rewards": { "xp": 50, "gold": 10, "fame": 5 },
+      "conditions": {
+        "minLevel": 1
+      }
+    },
+    {
+      "id": "side_001",
+      "name": "Caça aos Lobos",
+      "type": "secondary",
+      "description": "Os lobos estão ameaçando as colheitas. Derrote 5 lobos.",
+      "location": "vila_inicial",
+      "objectives": ["Derrotar 5 lobos"],
+      "rewards": { "xp": 20, "gold": 5, "fame": 2 },
+      "conditions": {
+        "minLevel": 1,
+        "relations": { "chefe_vila": 5 }
+      }
+    }
+  ]
+}

--- a/entities/entity.js
+++ b/entities/entity.js
@@ -12,17 +12,19 @@ class Entity {
    * @param {string} [options.name="???"] - Nome da entidade.
    * @param {number} [options.level=1] - Nível da entidade.
    * @param {number} [options.maxHp=100] - Pontos de vida máximos.
+   * @param {number} [options.maxMp=50] - Pontos de mana máximos.
    * @param {number} [options.atk=10] - Pontos de ataque.
    * @param {number} [options.def=5] - Pontos de defesa.
    * @param {number} [options.spd=5] - Pontos de velocidade.
    * @param {number} [options.gold=0] - Quantidade de ouro.
    * @param {Array} [options.skills=[]] - Lista de habilidades da entidade.
-   */
+  */
   constructor({
     id = null,
     name = "???",
     level = 1,
     maxHp = 100,
+    maxMp = 50,
     atk = 10,
     def = 5,
     spd = 5,
@@ -35,6 +37,9 @@ class Entity {
 
     this.maxHp = maxHp;
     this.hp = maxHp;
+
+    this.maxMp = maxMp;
+    this.mp = maxMp;
 
     this.atk = atk;
     this.def = def;
@@ -86,6 +91,15 @@ class Entity {
   }
 
   /**
+   * Restaura pontos de mana da entidade.
+   *
+   * @param {number} amount - Quantidade de MP a ser restaurada.
+   */
+  restoreMana(amount) {
+    this.mp = Math.min(this.mp + amount, this.maxMp);
+  }
+
+  /**
    * Aplica um efeito de status à entidade.
    * 
    * @param {string} effect - Nome do efeito a ser aplicado.
@@ -125,6 +139,8 @@ class Entity {
       level: this.level,
       hp: this.hp,
       maxHp: this.maxHp,
+      mp: this.mp,
+      maxMp: this.maxMp,
       atk: this.atk,
       def: this.def,
       spd: this.spd,

--- a/entities/npc.js
+++ b/entities/npc.js
@@ -22,12 +22,15 @@ class NPC extends Entity {
    * @param {number} [options.relationship=0] - Relacionamento com o jogador (-100 a 100).
    * @param {string} [options.role='villager'] - Papel do NPC (merchant, quest_giver, guard, etc.).
    * @param {Array} [options.dialogue=[]] - Lista de diálogos disponíveis.
-   */
+   * @param {Array} [options.dialogueFamous=[]] - Diálogos quando jogador tem alta fama.
+   * @param {Array} [options.schedules=[]] - Horários e locais onde o NPC pode ser encontrado.
+  */
   constructor({
     id = null,
     name = 'Pessoa',
     level = 1,
     maxHp = 50,
+    maxMp = 30,
     atk = 5,
     def = 2,
     spd = 3,
@@ -35,12 +38,16 @@ class NPC extends Entity {
     skills = [],
     relationship = 0, // -100..100
     role = 'villager', // merchant, quest_giver, guard...
-    dialogue = []
+    dialogue = [],
+    dialogueFamous = [],
+    schedules = []
   } = {}) {
-    super({ id, name, level, maxHp, atk, def, spd, gold, skills });
+    super({ id, name, level, maxHp, maxMp, atk, def, spd, gold, skills });
     this.relationship = relationship;
     this.role = role;
     this.dialogue = dialogue;
+    this.dialogueFamous = dialogueFamous;
+    this.schedules = schedules;
   }
 
   /**
@@ -63,6 +70,8 @@ class NPC extends Entity {
       relationship: this.relationship,
       role: this.role,
       dialogue: this.dialogue,
+      dialogueFamous: this.dialogueFamous,
+      schedules: this.schedules,
       type: 'NPC'
     };
   }
@@ -91,6 +100,7 @@ class NPC extends Entity {
       name: json.name,
       level: json.level,
       maxHp: json.maxHp,
+      maxMp: json.maxMp,
       atk: json.atk,
       def: json.def,
       spd: json.spd,
@@ -98,7 +108,9 @@ class NPC extends Entity {
       skills: json.skills,
       relationship: json.relationship,
       role: json.role,
-      dialogue: json.dialogue
+      dialogue: json.dialogue,
+      dialogueFamous: json.dialogueFamous,
+      schedules: json.schedules
     });
   }
 }

--- a/entities/player.js
+++ b/entities/player.js
@@ -14,6 +14,7 @@ class Player extends Entity {
    * @param {string} [options.name="Herói"] - Nome do jogador.
    * @param {number} [options.level=1] - Nível do jogador.
    * @param {number} [options.maxHp=100] - Pontos de vida máximos.
+   * @param {number} [options.maxMp=50] - Pontos de mana máximos.
    * @param {number} [options.atk=10] - Pontos de ataque.
    * @param {number} [options.def=5] - Pontos de defesa.
    * @param {number} [options.spd=5] - Pontos de velocidade.
@@ -22,12 +23,14 @@ class Player extends Entity {
    * @param {number} [options.xp=0] - Experiência atual.
    * @param {number} [options.xpToLevelUp=100] - Experiência necessária para o próximo nível.
    * @param {Array} [options.inventory=[]] - Inventário do jogador.
-   */
+   * @param {number} [options.fame=0] - Fama do jogador.
+  */
   constructor({
     id = null,
     name = "Herói",
     level = 1,
     maxHp = 100,
+    maxMp = 50,
     atk = 10,
     def = 5,
     spd = 5,
@@ -36,11 +39,13 @@ class Player extends Entity {
     xp = 0,
     xpToLevelUp = 100,
     inventory = [],
+    fame = 0,
   } = {}) {
-    super({ id, name, level, maxHp, atk, def, spd, gold, skills });
+    super({ id, name, level, maxHp, maxMp, atk, def, spd, gold, skills });
     this.xp = xp;
     this.xpToLevelUp = xpToLevelUp;
     this.inventory = inventory;
+    this.fame = fame;
   }
 
   /**
@@ -103,6 +108,7 @@ class Player extends Entity {
       xp: this.xp,
       xpToLevelUp: this.xpToLevelUp,
       inventory: this.inventory,
+      fame: this.fame,
       type: "Player",
     };
   }
@@ -139,6 +145,7 @@ class Player extends Entity {
       xp: json.xp,
       xpToLevelUp: json.xpToLevelUp,
       inventory: json.inventory,
+      fame: json.fame,
     });
   }
 }

--- a/index.js
+++ b/index.js
@@ -2,6 +2,9 @@ const InterfaceUtils = require("./utils/interfaceUtils");
 const GameManager = require("./managers/gameManager");
 const CharacterCreator = require("./core/characterCreator");
 const MapManager = require("./managers/mapManager");
+const QuestManager = require("./managers/questManager");
+const NPCManager = require("./managers/npcManager");
+const TimeManager = require("./managers/timeManager");
 const Player = require("./entities/player");
 
 /**
@@ -16,6 +19,9 @@ class TerminalRPG {
   constructor() {
     this.game = new GameManager();
     this.map = new MapManager(); // carrega e indexa worldMap.json
+    this.quest = new QuestManager(); // gerencia sistema de missões
+    this.npc = new NPCManager(); // gerencia NPCs
+    this.time = new TimeManager(); // ciclo de tempo
     this.isRunning = true;
   }
 
@@ -54,6 +60,7 @@ class TerminalRPG {
       break; // saiu do loop e segue para o menu principal
     }
 
+    this.time.start(this.game);
     await this.showMainMenu();
   }
 
@@ -67,6 +74,7 @@ class TerminalRPG {
     while (this.isRunning) {
       const choices = [
         { name: "Mapa", value: "map", symbol: "[M]" },
+        { name: "NPCs no local", value: "npcs", symbol: "[N]" },
         { name: "Menu de Missões", value: "quests", symbol: "[Q]" },
         { name: "Perfil do Jogador", value: "profile", symbol: "[P]" },
         { name: "Configurações", value: "configs", symbol: "[C]" },
@@ -89,6 +97,9 @@ class TerminalRPG {
       switch (selectedChoice) {
         case "map":
           await this.showMap();
+          break;
+        case "npcs":
+          await this.showNPCs();
           break;
         case "quests":
           await this.showQuests();
@@ -196,21 +207,190 @@ class TerminalRPG {
 
       // Se o novo destino for 'local' (ex.: loja_armas), aqui você abre o sistema correspondente
       // ex.: if (dest.type === 'local' && dest.id === 'loja_armas') openWeaponShop();
+      if (dest.type === 'inn') {
+        await this.openInn();
+      }
     }
   }
 
   /**
-   * Exibe o menu de missões.
-   * Funcionalidade placeholder que será implementada futuramente.
+   * Exibe o menu de missões e permite aceitar ou visualizar missões.
    *
    * @returns {Promise<void>} Promise que resolve quando o usuário volta ao menu.
    */
   async showQuests() {
+    while (true) {
+      InterfaceUtils.clearScreen();
+      InterfaceUtils.drawBox("[Q] MENU DE MISSÕES", 60);
+      console.log();
+
+      const choice = await InterfaceUtils.showChoices(
+        "Selecione:",
+        [
+          { name: "Quests disponíveis", value: "available", symbol: "[D]" },
+          { name: "Missões ativas", value: "active", symbol: "[A]" },
+          { name: "Voltar", value: "back", symbol: "[B]" },
+        ],
+        false
+      );
+
+      if (choice === "back") return;
+
+      if (choice === "available") {
+        const quests = this.quest.getAvailableQuests(this.game);
+        if (!quests.length) {
+          InterfaceUtils.showInfo("Nenhuma missão disponível aqui.");
+          await InterfaceUtils.waitForInput();
+          continue;
+        }
+
+        const opts = quests.map((q) => ({
+          name: `${q.name} (${q.type})`,
+          value: q.id,
+          symbol: ">",
+        }));
+        const picked = await InterfaceUtils.showChoices(
+          "Missões disponíveis:",
+          opts,
+          true
+        );
+        if (picked === "back") continue;
+
+        const q = this.quest.getQuestById(picked);
+        InterfaceUtils.clearScreen();
+        const detailLines = [
+          `[${q.name}]`,
+          `[${q.type.toUpperCase()}]`,
+          q.description,
+        ];
+        if (q.objectives?.length) {
+          detailLines.push('Objetivos:');
+          q.objectives.forEach((o) => detailLines.push(`- ${o}`));
+        }
+        if (q.rewards) {
+          const rewards = Object.entries(q.rewards)
+            .map(([k, v]) => `${k}: ${v}`)
+            .join(', ');
+          detailLines.push(`Recompensas: ${rewards}`);
+        }
+        InterfaceUtils.drawBox(detailLines, 60);
+        console.log();
+
+        const accept = await InterfaceUtils.confirm("Aceitar esta missão?");
+        if (accept) {
+          this.quest.acceptQuest(this.game, q.id);
+          this.game.save();
+          InterfaceUtils.showSuccess("Missão aceita!");
+        } else {
+          InterfaceUtils.showInfo("Missão rejeitada.");
+        }
+        await InterfaceUtils.waitForInput();
+      }
+
+      if (choice === "active") {
+        const active = this.quest.getActiveQuests(this.game);
+        if (!active.length) {
+          InterfaceUtils.showInfo("Nenhuma missão ativa.");
+          await InterfaceUtils.waitForInput();
+          continue;
+        }
+        const lines = active.map((q) => `[${q.type.toUpperCase()}] ${q.name}`);
+        InterfaceUtils.drawBox(lines, 60);
+        await InterfaceUtils.waitForInput();
+      }
+    }
+  }
+
+  /**
+   * Lista NPCs presentes na localização atual e permite interagir.
+   */
+  async showNPCs() {
     InterfaceUtils.clearScreen();
-    InterfaceUtils.drawBox("[Q] MENU DE MISSÕES", 60);
+    InterfaceUtils.drawBox("[N] NPCS", 60);
     console.log();
-    InterfaceUtils.showInfo("Sistema de missões será implementado em breve!");
-    await InterfaceUtils.waitForInput();
+
+    const here = this.map.getCurrentLocation(this.game);
+    const hour = this.time.getHour(this.game);
+    const npcs = here ? this.npc.getNPCsAt(here.id, hour) : [];
+    if (!npcs.length) {
+      InterfaceUtils.showInfo("Ninguém por perto.");
+      await InterfaceUtils.waitForInput();
+      return;
+    }
+    const opts = npcs.map((n) => ({ name: n.name, value: n.id, symbol: ">" }));
+    const pick = await InterfaceUtils.showChoices("Com quem deseja falar?", opts, true);
+    if (pick === "back") return;
+    const npc = this.npc.getNPCById(pick);
+    if (!npc) return;
+
+    await this.interactWithNPC(npc);
+  }
+
+  async interactWithNPC(npc) {
+    while (true) {
+      InterfaceUtils.clearScreen();
+      const fameDialogue =
+        this.game.player.fame >= 50 && npc.dialogueFamous.length
+          ? npc.dialogueFamous[0]
+          : npc.dialogue[0] || "...";
+      InterfaceUtils.drawBox([
+        `[${npc.name}]`,
+        fameDialogue,
+        `Relacionamento: ${this.getRelationship(npc.id)}`,
+      ], 60);
+      console.log();
+
+      const choice = await InterfaceUtils.showChoices(
+        "O que deseja fazer?",
+        [
+          { name: "Conversar", value: "talk", symbol: "[C]" },
+          { name: "Passar tempo", value: "spend", symbol: "[T]" },
+          { name: "Voltar", value: "back", symbol: "[B]" },
+        ],
+        false
+      );
+
+      if (choice === "back") return;
+      if (choice === "talk") {
+        this.changeRelationship(npc.id, 1);
+        InterfaceUtils.showInfo("Vocês conversam um pouco.");
+        await InterfaceUtils.waitForInput();
+      }
+      if (choice === "spend") {
+        this.changeRelationship(npc.id, 2);
+        this.time.advanceHour(this.game, 1);
+        InterfaceUtils.showInfo("O tempo passa enquanto vocês interagem.");
+        await InterfaceUtils.waitForInput();
+      }
+    }
+  }
+
+  changeRelationship(npcId, delta) {
+    this.game.flags.npcRelations = this.game.flags.npcRelations || {};
+    const cur = this.game.flags.npcRelations[npcId] || 0;
+    this.game.flags.npcRelations[npcId] = cur + delta;
+  }
+
+  getRelationship(npcId) {
+    return this.game.flags.npcRelations?.[npcId] || 0;
+  }
+
+  /**
+   * Abre o menu da estalagem, permitindo dormir para recuperar HP/MP e avançar o tempo.
+   */
+  async openInn() {
+    InterfaceUtils.clearScreen();
+    InterfaceUtils.drawBox("ESTALAGEM", 40);
+    console.log();
+    const confirm = await InterfaceUtils.confirm("Deseja dormir? (8 horas)");
+    if (confirm) {
+      const p = this.game.player;
+      p.heal(Math.floor(p.maxHp * 0.5));
+      p.restoreMana(Math.floor(p.maxMp * 0.5));
+      this.time.advanceHour(this.game, 8);
+      InterfaceUtils.showSuccess("Você descansou e se sente revigorado.");
+      await InterfaceUtils.waitForInput();
+    }
   }
 
   /**
@@ -234,11 +414,11 @@ class TerminalRPG {
     const profileLines = [
       `[NOME: ${p.name}].`,
       `[NÍVEL: ${p.level} (${p.xp}/${p.xpToLevelUp})].`,
-      `[HP: ${p.hp}/${p.maxHp}].`,
+      `[HP: ${p.hp}/${p.maxHp}] [MP: ${p.mp}/${p.maxMp}].`,
       `[FORÇA/ATK: ${p.atk}].`,
       `[AGILIDADE/SPD: ${p.spd}].`,
       `[FÍSICO/DEF: ${p.def}].`,
-      `[OURO: ${p.gold}].`,
+      `[OURO: ${p.gold}] [FAMA: ${p.fame}].`,
     ];
 
     // janela compacta no mesmo estilo do HUD
@@ -463,13 +643,16 @@ class TerminalRPG {
     const p = this.game.player;
     if (!p) return;
 
+    const here = this.map.getCurrentLocation(this.game);
     const lines = [
       `[NOME: ${p.name}].`,
       `[NÍVEL: ${p.level}].`,
-      `[HP: ${p.hp}/${p.maxHp}].`,
-      `[OURO: ${p.gold}].`,
-    ];
-    // largura ~40 deixa parecido com a imagem; ajuste se quiser
+      `[HP: ${p.hp}/${p.maxHp}] [MP: ${p.mp}/${p.maxMp}].`,
+      `[OURO: ${p.gold}] [FAMA: ${p.fame}].`,
+      here ? `[LOCAL: ${here.name}]` : '',
+      `[HORA: ${this.time.getFormattedTime(this.game)}]`,
+    ].filter(Boolean);
+
     InterfaceUtils.drawBox(lines, 40);
     console.log();
   }

--- a/managers/npcManager.js
+++ b/managers/npcManager.js
@@ -1,0 +1,40 @@
+// managers/npcManager.js
+const fs = require('fs');
+const path = require('path');
+const NPC = require('../entities/npc');
+
+class NPCManager {
+  constructor({ dataFile } = {}) {
+    this.dataFile = dataFile || path.resolve(__dirname, '../data/npcs.json');
+    this.npcs = [];
+    this.load();
+  }
+
+  load() {
+    if (!fs.existsSync(this.dataFile)) return;
+    const raw = JSON.parse(fs.readFileSync(this.dataFile, 'utf-8'));
+    this.npcs = Array.isArray(raw?.npcs)
+      ? raw.npcs.map((n) => NPC.fromJSON(n))
+      : [];
+  }
+
+  getNPCById(id) {
+    return this.npcs.find((n) => n.id === id) || null;
+  }
+
+  /**
+   * Lista NPCs presentes numa localidade em determinado horário.
+   * @param {string} locationId
+   * @param {number} hour
+   * @returns {NPC[]}
+   */
+  getNPCsAt(locationId, hour) {
+    return this.npcs.filter((npc) =>
+      npc.schedules?.some(
+        (s) => s.location === locationId && hour >= s.start && hour < s.end
+      )
+    );
+  }
+}
+
+module.exports = NPCManager;

--- a/managers/questManager.js
+++ b/managers/questManager.js
@@ -1,0 +1,94 @@
+// managers/questManager.js
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * @typedef {'primary'|'secondary'} QuestType
+ *
+ * @typedef {Object} Quest
+ * @property {string} id
+ * @property {string} name
+ * @property {QuestType} type
+ * @property {string} description
+ * @property {string} [location] - ID da localidade onde a missão está disponível
+ * @property {{ minLevel?: number, fame?: number, relations?: Object<string, number> }} [conditions]
+ * @property {Array<string>} [objectives]
+ * @property {Object<string, number>} [rewards]
+ */
+
+/**
+ * Gerencia o carregamento e estado das missões do jogo.
+ */
+class QuestManager {
+  /**
+   * @param {{ dataFile?: string }=} opts
+   */
+  constructor({ dataFile } = {}) {
+    this.dataFile = dataFile || path.resolve(__dirname, '../data/quests.json');
+    this.quests = [];
+    this.load();
+  }
+
+  /** Carrega o arquivo de missões. */
+  load() {
+    if (!fs.existsSync(this.dataFile)) return;
+    const raw = JSON.parse(fs.readFileSync(this.dataFile, 'utf-8'));
+    this.quests = Array.isArray(raw?.quests) ? raw.quests : [];
+  }
+
+  /**
+   * Obtém uma missão pelo ID.
+   * @param {string} id
+   * @returns {Quest|null}
+   */
+  getQuestById(id) {
+    return this.quests.find(q => q.id === id) || null;
+  }
+
+  /**
+   * Lista missões disponíveis considerando localização e condições.
+   * @param {import('./gameManager')} game
+   * @returns {Quest[]}
+   */
+  getAvailableQuests(game) {
+    const loc = game?.flags?.location || {};
+    const currentLoc = loc.localId || loc.villageId || loc.cityId;
+
+    return this.quests.filter(q => {
+      const status = game.flags?.quests?.[q.id];
+      if (status) return false;
+      if (q.location && q.location !== currentLoc) return false;
+      if (q.conditions?.minLevel && game.player.level < q.conditions.minLevel) return false;
+      if (q.conditions?.fame && game.player.fame < q.conditions.fame) return false;
+      if (q.conditions?.relations) {
+        for (const [npcId, min] of Object.entries(q.conditions.relations)) {
+          const rel = game.flags?.npcRelations?.[npcId] || 0;
+          if (rel < min) return false;
+        }
+      }
+      return true;
+    });
+  }
+
+  /**
+   * Marca uma missão como aceita.
+   * @param {import('./gameManager')} game
+   * @param {string} questId
+   */
+  acceptQuest(game, questId) {
+    game.flags.quests = game.flags.quests || {};
+    game.flags.quests[questId] = 'accepted';
+  }
+
+  /**
+   * Lista missões já aceitas pelo jogador.
+   * @param {import('./gameManager')} game
+   * @returns {Quest[]}
+   */
+  getActiveQuests(game) {
+    const qFlags = game.flags?.quests || {};
+    return this.quests.filter(q => qFlags[q.id] === 'accepted');
+  }
+}
+
+module.exports = QuestManager;

--- a/managers/timeManager.js
+++ b/managers/timeManager.js
@@ -1,0 +1,40 @@
+// managers/timeManager.js
+const DEFAULT_MS_PER_HOUR = 60000; // 1 minuto real = 1 hora no jogo
+
+class TimeManager {
+  constructor({ msPerHour = DEFAULT_MS_PER_HOUR } = {}) {
+    this.msPerHour = msPerHour;
+    this.timer = null;
+  }
+
+  start(game) {
+    if (!game.flags.time) game.flags.time = { hour: 8 };
+    if (this.timer) clearInterval(this.timer);
+    this.timer = setInterval(() => this.advanceHour(game, 1), this.msPerHour);
+  }
+
+  stop() {
+    if (this.timer) clearInterval(this.timer);
+  }
+
+  getHour(game) {
+    return (game.flags.time?.hour || 0) % 24;
+  }
+
+  advanceHour(game, hours = 1) {
+    game.flags.time = game.flags.time || { hour: 0 };
+    game.flags.time.hour = (game.flags.time.hour + hours) % 24;
+  }
+
+  isDay(game) {
+    const h = this.getHour(game);
+    return h >= 6 && h < 18;
+  }
+
+  getFormattedTime(game) {
+    const h = this.getHour(game).toString().padStart(2, '0');
+    return `${h}:00`;
+  }
+}
+
+module.exports = TimeManager;


### PR DESCRIPTION
## Summary
- show current location, time, and fame in the HUD
- add NPC and time managers with scheduled NPC encounters and inn resting
- extend quests with objectives, rewards, fame and relationship requirements

## Testing
- `node index.js`
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a3d1e5439c83319aa1fbaa85ced27a